### PR TITLE
Feature detect Mozilla, WebKit and IE browsers as jQuery.browser has been deprecated & removed

### DIFF
--- a/resizewithwindow/plugin.js
+++ b/resizewithwindow/plugin.js
@@ -69,13 +69,15 @@ CKEDITOR.plugins.add( 'resizewithwindow', {
 			
 			// Browser quirks: this correction prevents a vertical scroll bar in the window.
 			var extraheightCorrection = 8;
-			if ( jQuery.browser.mozilla ) {
+			var htmlStyle = document.documentElement.style;
+			
+			if ( 'mozAppearance' in htmlStyle ) {
 				extraheightCorrection = 11;
 			}
-			if ( jQuery.browser.webkit ) {
+			if ( 'webkitAppearance' in htmlStyle ) {
 				extraheightCorrection = 12;
 			}
-			if ( jQuery.browser.msie ) {
+			if ( 'behavior' in htmlStyle || '-ms-scroll-limit' in htmlStyle ) {
 				extraheightCorrection = 10;
 			}
 			baseEditorInnerGrey.height( referencedheight - extraheightCorrection );

--- a/resizewithwindow/plugin.js
+++ b/resizewithwindow/plugin.js
@@ -71,10 +71,10 @@ CKEDITOR.plugins.add( 'resizewithwindow', {
 			var extraheightCorrection = 8;
 			var htmlStyle = document.documentElement.style;
 			
-			if ( 'mozAppearance' in htmlStyle ) {
+			if ( 'MozAppearance' in htmlStyle ) {
 				extraheightCorrection = 11;
 			}
-			if ( 'webkitAppearance' in htmlStyle ) {
+			if ( 'WebkitAppearance' in htmlStyle ) {
 				extraheightCorrection = 12;
 			}
 			if ( 'behavior' in htmlStyle || '-ms-scroll-limit' in htmlStyle ) {


### PR DESCRIPTION
Otherwise it can't be used with jQuery 2.x and you get a JavaScript error in 1.10.x unless you also load the migrate plugin
